### PR TITLE
Trying to fix coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ install: "pip install -r requirements.txt"
 script: python -m unittest test_*.py
 
 after_success:
+  - coverage run test_*.py
+  - coverage report --show-missing
   - coveralls


### PR DESCRIPTION
Now travis can upload results to `https://coveralls.io/`. However, in the travis python environment even dependencies are tested (see build `#15` on [coveralls.io](https://coveralls.io/builds/21271902) and on [Travis CI](https://travis-ci.org/cnr-ibba/IMAGE-ValidationTool/builds/484290962))