### PR TITLE
Discovering tests with unittest

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Mar 20 12:45:08 2019
+
+@author: Paolo Cozzi <cozzi@ibba.cnr.it>
+"""
+

--- a/tests/test_ValidationResult.py
+++ b/tests/test_ValidationResult.py
@@ -108,3 +108,6 @@ class TestValidationResult(unittest.TestCase):
         expected_include_warning.append('Warning: term not match for Record sample_1')
         self.assertListEqual(collection.get_messages(), expected_include_warning)
 
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -131,3 +131,7 @@ class TestMisc(unittest.TestCase):
         self.assertRaises(TypeError, misc.extract_ontology_id_from_iri, 34)
         self.assertRaises(TypeError, misc.extract_ontology_id_from_iri, -12.34)
         self.assertRaises(TypeError, misc.extract_ontology_id_from_iri, True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_ruleset.py
+++ b/tests/test_ruleset.py
@@ -310,3 +310,7 @@ class TestRuleset(unittest.TestCase):
             summary_str = str(summary)
             actual_values.append(summary_str)
             self.assertListEqual(expected_result[error_type], actual_values)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_use_ontology.py
+++ b/tests/test_use_ontology.py
@@ -247,3 +247,7 @@ class TestUseOntology(unittest.TestCase):
         self.assertRaises(TypeError, cache.has_parent, True, "str")
         self.assertRaises(TypeError, cache.contains, 12)
         self.assertRaises(TypeError, cache.contains, True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -195,3 +195,7 @@ class TestValidation(unittest.TestCase):
             existing_results = ValidationResult.ValidationResultRecord(record['alias'])
             existing_results = validation.context_validation(record['attributes'], existing_results)
             self.assertListEqual(existing_results.get_messages(), expected[i])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Now, you can run test using unittest discover (as described [here](https://docs.python.org/3/library/unittest.html#test-discovery)):

```bash
$ python -m unittest
```
However see, how this build fails one test while in the [#71 passed](https://travis-ci.org/cnr-ibba/IMAGE-ValidationTool/builds/496501096) pass the same test