### PR TITLE
update ruleset with new sample storage type

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
 include README.rst
-include image_validation/sample_ruleset_v1.5.json
+include image_validation/sample_ruleset_v3a0ee76.json
 
 recursive-include tests *
 recursive-exclude * __pycache__

--- a/image_validation/sample_ruleset_v3a0ee76.json
+++ b/image_validation/sample_ruleset_v3a0ee76.json
@@ -778,6 +778,7 @@
                   "ambient temperature",
                   "cut slide",
                   "frozen, -80 degrees Celsius freezer",
+                  "frozen, -40 degrees Celsius freezer",
                   "frozen, -20 degrees Celsius freezer",
                   "frozen, liquid nitrogen",
                   "frozen, vapor phase",

--- a/image_validation/static_parameters.py
+++ b/image_validation/static_parameters.py
@@ -8,7 +8,7 @@ from . import use_ontology
 # ruleset file
 ruleset_filename = os.path.join(
     os.path.dirname(use_ontology.__file__),
-    "sample_ruleset_v1.5.json")
+    "sample_ruleset_v3a0ee76.json")
 
 # ontology cache
 ontology_library = use_ontology.OntologyCache()


### PR DESCRIPTION
* updated metadata rulet to last [version](https://github.com/cnr-ibba/IMAGE-metadata/tree/3a0ee7633fd43c2ccb0c5f281bfa9d5680256abc)